### PR TITLE
Header bug fix. Password module added and argument validation.

### DIFF
--- a/cross.cc
+++ b/cross.cc
@@ -42,6 +42,7 @@ void arguments(int argc, char** argv)
             std::cout << "2. Download development tools\nIncludes: Visual Studio Code, Visual studio's Installer, GIT" << std::endl;
             std::cout << "3. Download internet tools\nIncludes: FireFox, Chrome, Node, Python, Visual Studio's Installer" << std::endl;
             std::cout << "4. Download all of the above." << std::endl;
+            std::cout << "5. Remove the initial password from the Windows 10 VM" << std::endl;
             std::cin >> choice;
             if (choice == "1") {
                  std::cout << "Cyber security build selected" << std::endl;
@@ -59,11 +60,19 @@ void arguments(int argc, char** argv)
                 std::cout << "All of the above selected" << std::endl;
                 launch(4);
             }
-            if (choice != "1" && choice != "2" && choice != "3" && choice != "4") { 
+            if (choice == "5") {
+                std::cout << "Removing password:" << std::endl;
+                launch(5);
+            }
+            if (choice != "1" && choice != "2" && choice != "3" && choice != "4" && choice != "5") { 
                 //Currently their are 4 build options in this program. If choice is != to one of the four(may be more || less on Linux)
                 printf("Invalid build terminating program.");
                 exit(EXIT_FAILURE);
             }               
+        }
+        if (helpCompare != windows || helpCompare != linux) {
+            std::cout << "Unknown argument." << std::endl; std::cout << "Terminating program.";
+            exit(EXIT_FAILURE);
         }
     }
 }

--- a/main.hh
+++ b/main.hh
@@ -1,5 +1,5 @@
 //Core header files
-//-Wextra = extra warning flags
+//-Wextra = extra warning flags(Linux)
 #include <iostream> //C++
 #include <stdio.h> //C
 #include <stdlib.h> //C
@@ -7,7 +7,7 @@
 #include <stdbool.h> //false keyword
 //For the GCC compiler/I do not know if cl has the same parameters for headers.
 #if defined (_WIN32)
-    #include <windows.h>
+    #include "windows/windows.h"
     #include "windows/builds.c"
     #include "windows/windows.c"
     #include "cross.cc" //Independent file. This will call the launch function in Windows or Linux.

--- a/windows/builds.c
+++ b/windows/builds.c
@@ -7,6 +7,35 @@
     Origninally I planned on using classes. Currently I do not need hide and data or need access control.
     Structs appear to be better in this sitution
 */
+//After downloading X amount of VM's the password became annoying.
+struct initRemove {
+    int status = 0;
+    const wchar_t domainName = NULL; //Using the current domain
+    const wchar_t userName = NULL; //Using the current logged in user
+    const wchar_t *oldPassword = L"Passw0rd!"; //The default microsoft VM password
+    const wchar_t *newPassword = L""; //The new password value is blank. I'm removing the password. If you'd like a password type one within the quotes.
+    int removePassword() {
+        NET_API_STATUS nStatus;
+        nStatus = NetUserChangePassword(NULL,NULL,oldPassword,newPassword);
+        if (nStatus == 0){
+            printf("The password has been succesfully changed.");
+            status = EXIT_SUCCESS;
+            return status;
+        }
+        if (nStatus == 86) {
+            printf("You've entered the wrong password in the old password variable.\n");
+            status = EXIT_FAILURE;
+            return status;
+        }
+        else if (nStatus != 86 && nStatus != 0) {
+            printf("Unknown error. Error code: %d", nStatus);
+            status = EXIT_FAILURE;
+            return status;
+        }
+        return 0;
+    }
+};
+
 struct cyber {
     void cyberInit() {
         printf("Cyber build selected\n");

--- a/windows/windows.c
+++ b/windows/windows.c
@@ -52,6 +52,9 @@ int launch(int key) {
         struct all build;
         build.allInit();
     }
-    
+    if (key == 5) {
+        struct initRemove removeMe;
+        removeMe.removePassword();
+    }
     return status;
 }

--- a/windows/windows.h
+++ b/windows/windows.h
@@ -6,4 +6,9 @@
 //https://www.ibm.com/docs/en/i/7.4?topic=functions-fgets-read-string
 //Effective C
 #define WIN32_LEAN_AND_MEAN
+//Define WIN32_LEAN_AND_MEAN to exclude APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets.
+//^MSDN
 #include <windows.h>
+#pragma comment(lib, "netapi32.lib") 
+//NetUserChangePassword
+#include <lmaccess.h> //nstatus


### PR DESCRIPTION
Unknowingly I had a header error bug. Instead of using "windows.h", Initial was using <windows.h> which lacks <lmaccess.h>. This causes the NET_API_STATUS structure to be missing.

The password module removes the default Windows 10 virtual machine password "Passw0rd!". The password removal module can be used on any Windows 10 machine as long as you have the current password. All you need to do is change the oldPassword variable as well as the new one(if you don' want a password leave it blank).

Testing the arguments I realized that there was not support for unknown arguments if (-w or -l) is not supplied the program just exits. Initial is now more user friendly and exits with exit_failure.